### PR TITLE
[IMPR] Use host notifier instead public repository

### DIFF
--- a/Resources/views/Extension/notifier.html.twig
+++ b/Resources/views/Extension/notifier.html.twig
@@ -4,7 +4,7 @@
     ab.type = 'text/javascript'; ab.async = true;
     ab.onload = ab.onreadystatechange = callback;
     // this should match your copy of the compiled notifier.js or notifier.min.js
-    ab.src = (("https:" == document.location.protocol) ? "https://ssljscdn" : "http://jscdn") + ".airbrake.io/notifier.min.js";
+    ab.src = (("https:" == document.location.protocol) ? "https://" : "http://") + "{{ host }}/javascripts/notifier.js";
     var p = document.getElementsByTagName('script')[0];
     p.parentNode.insertBefore(ab, p);
     }(function () {


### PR DESCRIPTION
This improvement was inspired from: 
https://github.com/airbrake/airbrake/blob/master/lib/templates/javascript_notifier_loader

It's more safe to use host script path instead external airbrake.io site.

Works good with Airbrake and errbit.
