### PR TITLE
Allow enabling/disabling SSL support

### DIFF
--- a/Bridge/Configuration.php
+++ b/Bridge/Configuration.php
@@ -17,15 +17,17 @@ class Configuration extends BaseConfiguration
 {
     /**
      * Class constructor
-     * 
+     *
      * @param Configuration $configuration
      */
-    public function __construct($apiKey, $async, $env, $host)
+    public function __construct($apiKey, $async, $env, $host, $secure)
     {
         parent::__construct($apiKey, array(
             'async'           => $async,
             'environmentName' => $env,
-            'host'            => $host
+            'host'            => $host,
+            'secure'          => $secure,
+            'port'            => $secure ? 443 : 80
         ));
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -34,6 +34,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('api_key')->defaultFalse()->end()
                 ->booleanNode('async')->defaultTrue()->end()
                 ->scalarNode('host')->defaultValue('api.airbrake.io')->end()
+                ->scalarNode('secure')->defaultTrue()->end()
                 ->variableNode('ignored_exceptions')->defaultValue(array('Symfony\Component\HttpKernel\Exception\HttpException'))->end()
             ->end()
         ;

--- a/DependencyInjection/EoAirbrakeExtension.php
+++ b/DependencyInjection/EoAirbrakeExtension.php
@@ -39,12 +39,13 @@ class EoAirbrakeExtension extends Extension
         $container->setParameter('eo_airbrake.api_key', $config['api_key']);
         $container->setParameter('eo_airbrake.async', $config['async']);
         $container->setParameter('eo_airbrake.host', $config['host']);
+        $container->setParameter('eo_airbrake.secure', $config['secure']);
 
         // Exception Listener
         if ($config['api_key']) {
             // Airbreak Configuration
             $class = $container->getParameter('eo_airbrake.configuration.class');
-            $definition = new Definition($class, array($config['api_key'], $config['async'], $container->getParameter('kernel.environment'), $config['host']));
+            $definition = new Definition($class, array($config['api_key'], $config['async'], $container->getParameter('kernel.environment'), $config['host'], $config['secure']));
             $container->setDefinition('eo_airbrake.configuration', $definition);
 
             // Airbreak Client

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ eo_airbrake:
     # To log all exceptions leave this array empty.
     ignored_exceptions: ["Symfony\Component\HttpKernel\Exception\HttpException"]
 
+    # If you want to force override of whether or not to use SSL you can set secure to true/false whether or not to use SSL you can set secure to true/false
+    # By default secure is set to true
+    secure: true
 ```
 
 ## Usage


### PR DESCRIPTION
Allows you to set `secure` in the configuration. 

Setting to `true` uses SSL (default), otherwise `false` will just use port 80.
