### PR TITLE
Switch to dbtlr/php-airbrake

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "symfony/symfony": ">=2.1,<2.7-dev",
-        "airbrake/airbrake-php": "dev-master"
+        "dbtlr/php-airbrake": "dev-master"
     },
     "target-dir": "Eo/AirbrakeBundle",
     "autoload": {


### PR DESCRIPTION
The ``airbrake/airbrake-php`` package has been abandoned and was replaced with ``dbtlr/php-airbrake`` as noted in airbrake/airbrake-php@a3d1bb6cf4693dbd0e0fae8779cf7ac446480925.