### PR TITLE
Allow symfony-2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "symfony/symfony": ">=2.1,<2.7-dev",
+        "symfony/symfony": ">=2.1,<2.8-dev",
         "dbtlr/php-airbrake": "dev-master"
     },
     "target-dir": "Eo/AirbrakeBundle",


### PR DESCRIPTION
This allows bumping symfony to 2.7 in downstream projects. I did a quick test with my app and messages are still getting written to errbit as expected.

This bundle is the last blocker I'm seeing before I can upgrade to 2.7, so it'd be really nice if you could tag a new release of this bundle after merging this.

Thanks alot for this sweet little bundle :)